### PR TITLE
ObjectViewList: round size of emptyListMsg to int

### DIFF
--- a/ObjectListView2/ObjectListView.py
+++ b/ObjectListView2/ObjectListView.py
@@ -1777,11 +1777,11 @@ class ObjectListView(wx.ListCtrl):
         # Make sure our empty msg is reasonably positioned
         sz = self.GetClientSize()
         if 'phoenix' in wx.PlatformInfo:
-            self.stEmptyListMsg.SetSize(0, sz.GetHeight() / 3,
+            self.stEmptyListMsg.SetSize(0, int(sz.GetHeight() / 3),
                                         sz.GetWidth(),
                                         sz.GetHeight())
         else:
-            self.stEmptyListMsg.SetDimensions(0, sz.GetHeight() / 3,
+            self.stEmptyListMsg.SetDimensions(0, int(sz.GetHeight() / 3),
                                               sz.GetWidth(),
                                               sz.GetHeight())
         # self.stEmptyListMsg.Wrap(sz.GetWidth())


### PR DESCRIPTION
previously the empty List Message would not show up if sz.GetHeight() / 3 would yield a float